### PR TITLE
test different command line options

### DIFF
--- a/pandoc_tester.cmd
+++ b/pandoc_tester.cmd
@@ -1,5 +1,26 @@
-"C:/Program Files/RStudio/bin/pandoc/pandoc" --version
-"C:/Program Files/RStudio/bin/pandoc/pandoc" process_raw.md --from markdown --to html4 --output process_raw.html --email-obfuscation none --self-contained
-
 "C:/Program Files/Pandoc/pandoc" --version
+:: HTML4
+:: 1. @znmeb's example
 "C:/Program Files/Pandoc/pandoc" process_raw.md --from markdown --to html4 --output process_raw.html --email-obfuscation none --self-contained
+:: 2. remove `--self-contained`
+"C:/Program Files/Pandoc/pandoc" process_raw.md --from markdown --to html4 --output process_raw.html --email-obfuscation none
+:: 3. remove `--email-obfuscation none`
+"C:/Program Files/Pandoc/pandoc" process_raw.md --from markdown --to html4 --output process_raw.html --self-contained
+:: 4. add `--standalone`
+"C:/Program Files/Pandoc/pandoc" process_raw.md --from markdown --to html4 --output process_raw.html --email-obfuscation none --self-contained --standalone
+:: 5. remove `--self-contained`, add `--standalone`
+"C:/Program Files/Pandoc/pandoc" process_raw.md --from markdown --to html4 --output process_raw.html --email-obfuscation none --standalone
+
+:: HTML5
+:: 1. @znmeb's example
+"C:/Program Files/Pandoc/pandoc" process_raw.md --from markdown --to html5 --output process_raw.html --email-obfuscation none --self-contained
+:: 2. remove `--self-contained`
+"C:/Program Files/Pandoc/pandoc" process_raw.md --from markdown --to html5 --output process_raw.html --email-obfuscation none
+:: 3. remove `--email-obfuscation none`
+"C:/Program Files/Pandoc/pandoc" process_raw.md --from markdown --to html5 --output process_raw.html --self-contained
+:: 4. add `--standalone`
+"C:/Program Files/Pandoc/pandoc" process_raw.md --from markdown --to html5 --output process_raw.html --email-obfuscation none --self-contained --standalone
+:: 5. remove `--self-contained`, add `--standalone`
+"C:/Program Files/Pandoc/pandoc" process_raw.md --from markdown --to html5 --output process_raw.html --email-obfuscation none --standalone
+
+pause


### PR DESCRIPTION
I've added various command line options to the `cmd` file. I think we've established that v2.5 is broken, so I've removed those lines.